### PR TITLE
feat(setup-node): default upgrade-npm to false

### DIFF
--- a/setup-node-and-install/action.yml
+++ b/setup-node-and-install/action.yml
@@ -26,7 +26,7 @@ inputs:
     description:
       Whether to upgrade npm to v11.5.1. This is required for OIDC trusted publishing but can be disabled if you want to
       shave off some run time and you are still using token-based authentication.
-    default: true
+    default: false
 
 outputs:
   node-version:


### PR DESCRIPTION
BREAKING CHANGE: upgrade-npm is defaulted to false for the setup-node-and-install action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration: npm upgrade for OIDC support now requires explicit opt-in rather than running by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->